### PR TITLE
Update and restructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+js/.DS_Store
+.DS_Store

--- a/class-jquery-migrate-helper.php
+++ b/class-jquery-migrate-helper.php
@@ -103,7 +103,7 @@ class jQuery_Migrate_Helper {
 
 			<ol class="jquery-migrate-deprecation-list"></ol>
 
-            <p><?php _e( 'Please make sure you are using the latest version for any of the plugins or themes listed above. If you are, you should consider reaching out to their respective developers for an update.' ); ?></p>
+			<p><?php _e( 'Please make sure you are using the latest version for any of the plugins or themes listed above. If you are, you should consider reaching out to their respective developers for an update.' ); ?></p>
 		</div>
 
 		<?php
@@ -129,7 +129,7 @@ class jQuery_Migrate_Helper {
 			<h2><?php _ex( 'jQuery Migrate Helper', 'Admin notice header', 'enable-jquery-migrate-helper' ); ?></h2>
 			<p><?php _e( 'You are currently using a migration helper for jQuery script added by your theme and plugins. Please check if you still need this helper.' ,'enable-jquery-migrate-helper' ); ?></p>
 			<p><?php _e( 'While browsing in the backend, you will see warnings about deprecated scripts.', 'enable-jquery-migrate-helper' ); ?></p>
-            <p>
+			<p>
 				<?php
 
 				printf(
@@ -143,8 +143,8 @@ class jQuery_Migrate_Helper {
 				);
 
 				?>
-            </p>
-            <?php wp_nonce_field( 'jquery-migrate-notice', 'jquery-migrate-notice-nonce', false ); ?>
+			</p>
+			<?php wp_nonce_field( 'jquery-migrate-notice', 'jquery-migrate-notice-nonce', false ); ?>
 		</div>
 
 		<?php

--- a/class-jquery-migrate-helper.php
+++ b/class-jquery-migrate-helper.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Class jQuery_Migrate_Helper,
+ *
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Invalid request.' );
+}
+
+class jQuery_Migrate_Helper {
+
+	private function __construct() {}
+
+	public static function init_actions() {
+		// To be able to replace the src, scripts should not be concatenated.
+		if ( ! defined( 'CONCATENATE_SCRIPTS' ) ) {
+			define( 'CONCATENATE_SCRIPTS', false );
+		}
+
+		$GLOBALS['concatenate_scripts'] = false;
+
+		add_action( 'wp_default_scripts', array( __CLASS__, 'replace_scripts' ), -1 );
+
+		// We need our own script for displaying warnings to run as late as possible.
+		// Print it separately after the footer scripts.
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'register_scripts' ) );
+		add_action( 'admin_print_footer_scripts', array( __CLASS__, 'print_scripts' ), 100 );
+
+		add_action( 'admin_notices', array( __CLASS__, 'admin_notices' ) );
+		add_action( 'wp_ajax_jquery-migrate-dismiss-notice', array( __CLASS__, 'admin_notices_dismiss' ) );
+	}
+
+	// Pre-register scripts on 'wp_default_scripts' action, they won't be overwritten by $wp_scripts->add().
+	private static function set_script( $scripts, $handle, $src, $deps = array(), $ver = false, $in_footer = false ) {
+		$script = $scripts->query( $handle, 'registered' );
+
+		if ( $script ) {
+			// If already added
+			$script->src  = $src;
+			$script->deps = $deps;
+			$script->ver  = $ver;
+			$script->args = $in_footer;
+
+			unset( $script->extra['group'] );
+
+			if ( $in_footer ) {
+				$script->add_data( 'group', 1 );
+			}
+		} else {
+			// Add the script
+			if ( $in_footer ) {
+				$scripts->add( $handle, $src, $deps, $ver, 1 );
+			} else {
+				$scripts->add( $handle, $src, $deps, $ver );
+			}
+		}
+	}
+
+	/*
+	 * Enqueue jQuery migrate, and force it to be the development version.
+	 *
+	 * This will ensure that console errors are generated, and we can surface these to the
+	 * end user in a responsible manner so that they can update their plugins and theme,
+	 * or make a decision to switch to other plugin/theme if no updates are available.
+	 */
+	public static function replace_scripts( $scripts ) {
+		$assets_url = plugins_url( 'js/', __FILE__ );
+
+		self::set_script( $scripts, 'jquery-migrate', $assets_url . 'jquery-migrate-1.4.1-wp.js', array(), '1.4.1-wp' );
+		self::set_script( $scripts, 'jquery', false, array( 'jquery-core', 'jquery-migrate' ), '1.12.4-wp' );
+	}
+
+	/**
+	 * Register the deprecation notice capture handler script.
+	 */
+	public static function register_scripts() {
+		wp_register_script( 'jquery-migrate-deprecation-notices', plugins_url( 'js/deprecation-notice.js', __FILE__ ), array( 'jquery' ), false, true );
+	}
+
+	/**
+	 * Output/print the deprecation notice script. Needs to be last in the footer.
+	 */
+	public static function print_scripts() {
+		wp_print_scripts( 'jquery-migrate-deprecation-notices' );
+	}
+
+	/**
+	 * HTML for jQuery Migrate deprecated notices.
+	 *
+	 * This notice is only displayed if there are JS migration deprecation notices
+	 * for scripts loaded on the current screen.
+	 *
+	 * @since 1.0.0
+	 */
+	public static function deprecated_scripts_notice() {
+		?>
+
+		<div class="notice notice-error is-dismissible jquery-migrate-deprecation-notice hidden">
+			<h2><?php _ex( 'jQuery Migrate Helper', 'Admin notice header', 'enable-jquery-migrate-helper' ); ?> &mdash; <?php _ex( 'Warnings encountered', 'enable-jquery-migrate-helper' ); ?></h2>
+			<p><?php _e( 'A deprecated function means it will be removed in an upcoming update, and should be replaced with more modern code.', 'enable-jquery-migrate-helper' ); ?></p>
+			<p><?php _e( 'The following notices were encountered on this page:', 'enable-jquery-migrate-helper' ); ?></p>
+
+			<ol class="jquery-migrate-deprecation-list"></ol>
+
+            <p><?php _e( 'Please make sure you are using the latest version for any of the plugins or themes listed above. If you are, you should consider reaching out to their respective developers for an update.' ); ?></p>
+		</div>
+
+		<?php
+	}
+
+	/**
+	 * HTML for the Dashboard notice.
+	 */
+	public static function dashboard_notice() {
+		// Show again in two seeks if the user has dismissed this notice.
+		$is_dismissed = get_option( '_jquery_migrate_dismissed_notice', false );
+		$recurrence   = 2 * WEEK_IN_SECONDS;
+
+		// If the message has been dismissed, and it has been less than two weeks since it was seen,
+		// then skip showing the admin notice for now.
+		if ( false !== $is_dismissed && $is_dismissed > ( time() - $recurrence ) ) {
+			return;
+		}
+
+		?>
+
+		<div class="notice notice-warning is-dismissible jquery-migrate-dashboard-notice">
+			<h2><?php _ex( 'jQuery Migrate Helper', 'Admin notice header', 'enable-jquery-migrate-helper' ); ?></h2>
+			<p><?php _e( 'You are currently using a migration helper for jQuery script added by your theme and plugins. Please check if you still need this helper.' ,'enable-jquery-migrate-helper' ); ?></p>
+			<p><?php _e( 'While browsing in the backend, you will see warnings about deprecated scripts.', 'enable-jquery-migrate-helper' ); ?></p>
+            <p>
+				<?php
+
+				printf(
+					// translators: %s: `Console Log` link
+					__( 'To find out more about what plugin or theme is causing issues for the public part of yoru site, please consult your %s.', 'enable-jquery-migrate-helper' ),
+					sprintf(
+						'<a href="%s">%s</a>',
+						_x( 'https://wordpress.org/support/article/using-your-browser-to-diagnose-javascript-errors/#step-3-diagnosis', 'URL to article about debugging JavaScript', 'enable-jquery-migrate-helper' ),
+						__( 'Console Log', 'enable-jquery-migrate-helper' )
+					)
+				);
+
+				?>
+            </p>
+            <?php wp_nonce_field( 'jquery-migrate-notice', 'jquery-migrate-notice-nonce', false ); ?>
+		</div>
+
+		<?php
+	}
+
+	public static function admin_notices() {
+		// Show only to admins.
+		if ( ! current_user_can( 'update_plugins' ) ) {
+			return;
+		}
+
+		if ( get_current_screen()->id === 'dashboard' ) {
+			self::dashboard_notice();
+		}
+
+		self::deprecated_scripts_notice();
+	}
+
+	public static function admin_notices_dismiss() {
+		if ( empty( POST['dismiss-notice-nonce'] ) || ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( ! wp_verify_nonce( POST['dismiss-notice-nonce'], 'jquery-migrate-notice' ) ) {
+			return;
+		}
+
+		update_option( '_jquery_migrate_dismissed_notice', time() );
+	}
+}

--- a/enable-jquery-migrate-helper.php
+++ b/enable-jquery-migrate-helper.php
@@ -4,7 +4,7 @@ Plugin Name: Enable jQuery Migrate Helper
 Plugin URI: https://wordpress.org/plugins/enable-jquery-migrate-helper
 Description: Enable support for old and outdated plugins and themes during a jQuery update transitional phase.
 Version: 1.0.0
-Requires at least: 5.5
+Requires at least: 5.4
 Tested up to: 5.5
 Requires PHP: 5.6
 Author: The WordPress Team

--- a/enable-jquery-migrate-helper.php
+++ b/enable-jquery-migrate-helper.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Invalid request.' );
 }
 
-if ( ! class_exists( 'jQuery_Migrate_Helper' ) ) {
+if ( version_compare( $GLOBALS['wp_version'], '5.6-alpha', '<' ) && ! class_exists( 'jQuery_Migrate_Helper' ) ) {
 	include_once __DIR__ . '/class-jquery-migrate-helper.php';
 	add_action( 'plugins_loaded', array( 'jQuery_Migrate_Helper', 'init_actions' ) );
 }

--- a/enable-jquery-migrate-helper.php
+++ b/enable-jquery-migrate-helper.php
@@ -2,152 +2,24 @@
 /*
 Plugin Name: Enable jQuery Migrate Helper
 Plugin URI: https://wordpress.org/plugins/enable-jquery-migrate-helper
-Description: Enable the jQuery Migrate helper feature during a transitional phase
-Version: 0.1.0
-Author: Clorith
-Author URI: https://www.clorith.net
+Description: Enable support for old and outdated plugins and themes during a jQuery update transitional phase.
+Version: 1.0.0
+Requires at least: 5.5
+Tested up to: 5.5
+Requires PHP: 5.6
+Author: The WordPress Team
+Author URI: https://wordpress.org
+Contributors: wordpressdotorg, clorith, azaozz
 License: GPLv2
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: enable-jquery-migrate-helper
 */
 
-class jQuery_Migrate_Helper {
-
-	public function __construct() {
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue' ), 1 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ), 1 );
-		add_action( 'login_enqueue_scripts', array( $this, 'enqueue' ), 1 );
-
-		// We need our own script for displaying warnings to run as late as possible on the site.
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_footer' ), PHP_INT_MAX );
-
-		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
-		add_action( 'wp_ajax_jquery-migrate-dismiss-notice', array( $this, 'admin_notices_dismiss' ) );
-	}
-
-	/**
-	 * Enqueue our script assets.
-	 *
-	 * @since 0.1.0
-	 *
-	 * @return void
-	 */
-	public function enqueue() {
-		/*
-		 * Enqueue jQuery migrate, and force it to be the development version.
-		 *
-		 * This will ensure that console errors are generated, and we can surface these to the
-		 * end user in a responsible manner so that they can reach out to authors of themes
-		 * or plugins and get their code updated.
-		 */
-		wp_deregister_script( 'jquery-migrate' );
-		wp_enqueue_script( 'jquery-migrate', plugins_url( 'js/jquery-migrate.js', __FILE__ ), array( 'jquery' ), '1.4.1-ejqmh', false );
-	}
-
-	/**
-	 * Enqueue the deprecation notice capture handler.
-	 */
-	public function enqueue_footer() {
-		wp_enqueue_script( 'jquery-migrate-deprecation-notices', plugins_url( 'js/deprecation-notice.js', __FILE__ ), array( 'jquery' ), false, true );
-	}
-
-	/**
-	 * Display admin notices.
-	 *
-	 * @since 0.1.0
-	 *
-	 * @return void
-	 */
-	public function admin_notices() {
-		// Do not show notices for regular editors or authors.
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
-
-		/*
-		 * The first notice is only displayed if there are JS migration deprecation notices.
-		 */
-		?>
-
-		<div class="notice notice-error" id="jquery-migrate-deprecation-notice" style="display:none;">
-			<h2><?php _ex( 'jQuery Migrate Helper', 'Admin notice header', 'enable-jquery-migrate-helper' ); ?> &mdash; <?php _ex( 'Warnings encountered', 'enable-jquery-migrate-helper' ); ?></h2>
-
-			<p>
-				<?php _e( 'A deprecated function means it will be removed in an upcoming update, and should be replaced with more modern code.', 'enable-jquery-migrate-helper' ); ?>
-			</p>
-
-			<p>
-				<?php _e( 'The following notices were encountered on this page:', 'enable-jquery-migrate-helper' ); ?>
-			</p>
-
-			<ol id="jquery-migrate-deprecation-list"></ol>
-
-
-            <p>
-                <?php _e( 'Please make sure you are using the latest version for any of the plugins or themes listed above. If you are, you should consider reaching out to their respective developers for an update.' ); ?>
-            </p>
-		</div>
-
-		<?php
-
-		$message_dismissed = get_option( '_jquery_migrate_dismissed_notice', false);
-
-		$recurrence = 2 * WEEK_IN_SECONDS;
-
-		/*
-		 * If the message has been dismissed, and it has been less than two weeks since it was seen,
-		 * then skip showing the admin notice for now.
-		 */
-		if ( false !== $message_dismissed && $message_dismissed > ( time() - $recurrence ) ) {
-			return;
-		}
-
-		?>
-
-		<div class="notice notice-warning is-dismissible" id="jquery-migrate-notice">
-			<h2><?php _ex( 'jQuery Migrate Helper', 'Admin notice header', 'enable-jquery-migrate-helper' ); ?></h2>
-			<p>
-				<?php _e( 'You are currently using a migration helper for the jQuery script, please check if your theme and plugins still rely on this.' ,'enable-jquery-migrate-helper' ); ?>
-			</p>
-
-            <p>
-                <?php _e( 'While browsing in the backend, you will be shown a notice if any warnings are detected. ', 'enable-jquery-migrate-helper' ); ?>
-            </p>
-
-            <p>
-				<?php
-				printf(
-				// translators: %s: `Console Log` link
-					__( 'To find out more about what plugin or theme is causing issues for the public part of yoru site, please consult your %s.', 'enable-jquery-migrate-helper' ),
-					sprintf(
-						'<a href="%s">%s</a>',
-						_x( 'https://wordpress.org/support/article/using-your-browser-to-diagnose-javascript-errors/#step-3-diagnosis', 'URL to article about debugging JavaScript', 'enable-jquery-migrate-helper' ),
-						__( 'Console Log', 'enable-jquery-migrate-helper' )
-					)
-				);
-				?>
-            </p>
-		</div>
-		<script type="text/javascript">
-			jQuery( 'body' ).on( 'click', '.notice-dismiss', function() {
-				jQuery.post(
-					'<?php echo esc_js( admin_url( 'admin-ajax.php' ) ); ?>',
-					{
-						action: 'jquery-migrate-dismiss-notice'
-					}
-				);
-			} );
-		</script>
-
-		<?php
-	}
-
-	public function admin_notices_dismiss() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
-
-		update_option( '_jquery_migrate_dismissed_notice', time() );
-	}
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Invalid request.' );
 }
 
-new jQuery_Migrate_Helper();
+if ( ! class_exists( 'jQuery_Migrate_Helper' ) ) {
+	include_once __DIR__ . '/class-jquery-migrate-helper.php';
+	add_action( 'plugins_loaded', array( 'jQuery_Migrate_Helper', 'init_actions' ) );
+}

--- a/js/jquery-migrate-1.4.1-wp.js
+++ b/js/jquery-migrate-1.4.1-wp.js
@@ -38,15 +38,20 @@ jQuery.migrateReset = function() {
 
 function migrateWarn( msg) {
 	var console = window.console;
-	if ( !warnedAbout[ msg ] ) {
+	var error   = new Error();
+
+	// WP: Add all warnings to jQuery.migrateWarnings.
+	var tracedError = {
+		warning: msg,
+		trace: error.stack || error
+	};
+
+	jQuery.migrateWarnings.push( tracedError );
+	// WP: end.
+
+	if ( ! warnedAbout[ msg ] ) {
 		warnedAbout[ msg ] = true;
 
-		var tracedError = {
-			'warning': msg,
-			'trace': Error().stack
-		};
-
-		jQuery.migrateWarnings.push( tracedError );
 		if ( console && console.warn && !jQuery.migrateMute ) {
 			console.warn( "JQMIGRATE: " + msg );
 			if ( jQuery.migrateTrace && console.trace ) {

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Enable jQuery Migrate Helper ===
 Contributors: wordpressdotorg, clorith, azaozz
-Requires at least: 5.5
+Requires at least: 5.4
 Tested up to: 5.5
 Stable tag: 1.0.0
 Requires PHP: 5.6

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,11 @@
 === Enable jQuery Migrate Helper ===
-Contributors: wordpressdotorg, Clorith
+Contributors: wordpressdotorg, clorith, azaozz
+Requires at least: 5.5
 Tested up to: 5.5
-Stable tag: 0.1.0
-License: GPLv2 or late
+Stable tag: 1.0.0
 Requires PHP: 5.6
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
@@ -13,11 +15,11 @@ This plugin serves as a temporary solution, enabling the migration script for yo
 
 == Installation ==
 
-1. Upload to your plugins folder, usually `wp-content/plugins/`
+1. Upload to your plugins folder, usually `wp-content/plugins/`.
 2. Activate the plugin on the plugin screen.
 3. That's it! The plugin handles the rest automatically for you.
 
 == Changelog ==
 
-= v 0.1.0 =
-* Initial release
+= v 1.0.0 =
+* Initial release.


### PR DESCRIPTION
- Make the class static and move in a separate file.
- Change the method of defining/overriding scripts in script-loader.
- Tweak the js, clean up a bit more from the trace strings.
- Add nonce when saving the dismiss action.
- Rename jquery-migrate.js to jquery-migrate-1.4.1-wp.js