### PR TITLE
Change the plugin’s text-domain and update the translatable strings accordingly

### DIFF
--- a/class-jquery-migrate-helper.php
+++ b/class-jquery-migrate-helper.php
@@ -97,16 +97,16 @@ class jQuery_Migrate_Helper {
 		?>
 
 		<div class="notice notice-error is-dismissible jquery-migrate-deprecation-notice hidden">
-			<h2><?php _ex( 'jQuery Migrate Helper', 'Admin notice header', 'enable-jquery-migrate-helper' ); ?> &mdash; <?php _ex( 'Warnings encountered', 'enable-jquery-migrate-helper' ); ?></h2>
-			<p><?php _e( 'This page generated the following warnings:', 'enable-jquery-migrate-helper' ); ?></p>
+			<h2><?php _ex( 'jQuery Migrate Helper', 'Admin notice header', 'jquery-migrate-helper' ); ?> &mdash; <?php _ex( 'Warnings encountered', 'jquery-migrate-helper' ); ?></h2>
+			<p><?php _e( 'This page generated the following warnings:', 'jquery-migrate-helper' ); ?></p>
 
 			<ol class="jquery-migrate-deprecation-list"></ol>
 
-			<p><?php _e( 'Please make sure you\'re using the latest version of all of your plugins, and your theme. If you are, you might want to ask their developers for an update.', 'enable-jquery-migrate-helper' ); ?></p>
+			<p><?php _e( 'Please make sure you\'re using the latest version of all of your plugins, and your theme. If you are, you might want to ask their developers for an update.', 'jquery-migrate-helper' ); ?></p>
             <p>
-				<?php _e( 'A script, a file, or some other piece of code is <strong>deprecated</strong> when its developers are in the process of replacing it with more modern code or removing it entirely from its environment.', 'enable-jquery-migrate-helper' ); ?>
+				<?php _e( 'A script, a file, or some other piece of code is <strong>deprecated</strong> when its developers are in the process of replacing it with more modern code or removing it entirely from its environment.', 'jquery-migrate-helper' ); ?>
                 <br>
-				<?php _e( 'If you get a warning, you should check the theme or plugin that generated it for an update—there will very likely be one you can install.', 'enable-jquery-migrate-helper' ); ?>
+				<?php _e( 'If you get a warning, you should check the theme or plugin that generated it for an update—there will very likely be one you can install.', 'jquery-migrate-helper' ); ?>
             </p>
 		</div>
 
@@ -130,13 +130,13 @@ class jQuery_Migrate_Helper {
 		?>
 
 		<div class="notice notice-warning is-dismissible jquery-migrate-dashboard-notice">
-			<h2><?php _ex( 'jQuery Migrate Helper', 'Admin notice header', 'enable-jquery-migrate-helper' ); ?></h2>
-			<p><?php _e( 'Right now you are using a helper JavaScript that your theme or one or more of your plugins installed to help your site run some old code, but it\'s possible you no longer need it.' ,'enable-jquery-migrate-helper' ); ?></p>
-			<p><?php _e( 'To check, please deactivate the jQuery Migrate Helper plugin and then browse the WordPress dashboard. If you see errors or warnings about deprecated scripts, you should reactivate jQuery Migrate Helper.', 'enable-jquery-migrate-helper' ); ?></p>
+			<h2><?php _ex( 'jQuery Migrate Helper', 'Admin notice header', 'jquery-migrate-helper' ); ?></h2>
+			<p><?php _e( 'Right now you are using a helper JavaScript that your theme or one or more of your plugins installed to help your site run some old code, but it\'s possible you no longer need it.' , 'jquery-migrate-helper' ); ?></p>
+			<p><?php _e( 'To check, please deactivate the jQuery Migrate Helper plugin and then browse the WordPress dashboard. If you see errors or warnings about deprecated scripts, you should reactivate jQuery Migrate Helper.', 'jquery-migrate-helper' ); ?></p>
 			<p>
-                <?php _e( 'A script, a file, or some other piece of code is <strong>deprecated</strong> when its developers are in the process of replacing it with more modern code or removing it entirely from its environment.', 'enable-jquery-migrate-helper' ); ?>
+                <?php _e( 'A script, a file, or some other piece of code is <strong>deprecated</strong> when its developers are in the process of replacing it with more modern code or removing it entirely from its environment.', 'jquery-migrate-helper' ); ?>
                 <br>
-                <?php _e( 'If you get a warning, you should check the theme or plugin that generated it for an update—there will very likely be one you can install.', 'enable-jquery-migrate-helper' ); ?>
+                <?php _e( 'If you get a warning, you should check the theme or plugin that generated it for an update—there will very likely be one you can install.', 'jquery-migrate-helper' ); ?>
             </p>
 			<?php wp_nonce_field( 'jquery-migrate-notice', 'jquery-migrate-notice-nonce', false ); ?>
 		</div>

--- a/enable-jquery-migrate-helper.php
+++ b/enable-jquery-migrate-helper.php
@@ -12,7 +12,7 @@ Author URI: https://wordpress.org
 Contributors: wordpressdotorg, clorith, azaozz
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Text Domain: enable-jquery-migrate-helper
+Text Domain: jquery-migrate-helper
 */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
The plugin text-domain should probably be `jquery-migrate-helper`.
This pull request updates the plugin text-domain in the main file header and in the translatable strings.